### PR TITLE
add support for pravega-0.6.0 / 0.13-W13

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ export KEYCLOAK_SERVICE_ACCOUNT_FILE=${HOME}/keycloak.json
   `tcp://nautilus-pravega-controller.nautilus-pravega.svc.cluster.local:9090`
 
 - External:
-  Run the following command and find the external IP:
-  `kubectl get -n nautilus-pravega svc/nautilus-pravega-controller`
-  The Pravega Controller URL will be `tls://EXTERNAL-IP:443`
+  Run the following command and find the external FQDN in the HOSTS column:
+  `kubectl get -n nautilus-pravega ing/pravega-controller`
+  The Pravega Controller URL will be `tls://pravega-controller.FQDN:443`
 
 ### Running the Examples in IntelliJ
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ docker run -it --rm -e HOST_IP -p 9090:9090 -p 10080:9091 -p 12345:12345 pravega
 curl -X POST -H "Content-Type: application/json" -d '{"scopeName":"examples"}' http://localhost:10080/v1/scopes
 ```
 
-### (Local, External) Install Pravega Client and Pravega Flink Connector Libraries
+### (Local only) Install Pravega Client and Pravega Flink Connector Libraries
 
 This step is required when using pre-release versions of Pravega and/or Nautilus.
 It will install required libraries in the local Maven repository.
 This can be skipped in Nautilus SDK Desktop as it has already been performed.
+This can also be skipped with 0.13-W11 release
 
 ```
 cd
@@ -133,22 +134,9 @@ If necessary, edit the file `gradle.properties` to include the following line.
 includePravegaCredentials=true
 ```
 
-### (External) Configure Nautilus Authentication
-
-Obtain the file pravega-keycloak-credentials-*.jar and place it in the lib directory.
-
-```
-sudo apt install maven
-PRAVEGA_CREDENTIALS_VERSION=0.6.0-2345.298015f-0.12.0-W5-001.4e5c9a1
-mvn install:install-file \
--Dfile=lib/pravega-keycloak-credentials-${PRAVEGA_CREDENTIALS_VERSION}-shadow.jar \
--DgroupId=io.pravega -DartifactId=pravega-keycloak-credentials \
--Dversion=${PRAVEGA_CREDENTIALS_VERSION} -Dpackaging=jar
-```
-
 Obtain the Pravega authentication credentials.
 ```
-kubectl get secret examples-pravega -n examples -o jsonpath="{.data.keycloak\.json}" | base64 -d > ${HOME}/keycloak.json
+PROJECT=examples ; kubectl get secret ${PROJECT}-pravega -n ${PROJECT} -o jsonpath="{.data.keycloak\.json}" | base64 -d | python -m json.tool > ~/keycloak.json
 chmod go-rw ${HOME}/keycloak.json
 ```
 
@@ -172,7 +160,7 @@ export KEYCLOAK_SERVICE_ACCOUNT_FILE=${HOME}/keycloak.json
 - External:
   Run the following command and find the external IP:
   `kubectl get -n nautilus-pravega svc/nautilus-pravega-controller`
-  The Pravega Controller URL will be `tcp://EXTERNAL-IP:9090`
+  The Pravega Controller URL will be `tls://EXTERNAL-IP:443`
 
 ### Running the Examples in IntelliJ
 

--- a/camera-recorder/build.gradle
+++ b/camera-recorder/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile "org.bytedeco:javacv-platform:1.5.1"
     compile "io.pravega:pravega-client:${pravegaVersion}"
     if (includePravegaCredentials.toBoolean()) {
-        compile "io.pravega:pravega-keycloak-credentials:${pravegaCredentialsVersion}"
+        compile "io.pravega:pravega-keycloak-client:${pravegaCredentialsVersion}"
     }
     testCompile "junit:junit:${junitVersion}"
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
+    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    compile "io.pravega:pravega-client:${pravegaVersion}"    
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/flinkprocessor/build.gradle
+++ b/flinkprocessor/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile "ch.qos.logback:logback-classic:${logbackVersion}"
     compile "ch.qos.logback:logback-core:${logbackVersion}"
     compile "net.logstash.logback:logstash-logback-encoder:${logstashLogbackEncoderVersion}"
-    compile "io.pravega:pravega-connectors-flink_${flinkScalaVersion}:${pravegaFlinkConnectorVersion}"
+    compile "io.pravega:pravega-connectors-flink-${flinkShortVersion}_${flinkScalaVersion}:${pravegaFlinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-streaming-scala_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-ml_${flinkScalaVersion}:${flinkVersion}"
@@ -56,7 +56,7 @@ dependencies {
     compile "io.pravega:pravega-client:${pravegaVersion}"
 
     if (includePravegaCredentials.toBoolean()) {
-        compile "io.pravega:pravega-keycloak-credentials:${pravegaCredentialsVersion}"
+        compile "io.pravega:pravega-keycloak-client:${pravegaCredentialsVersion}"
     }
 
     compile "com.github.vladimir-bukhtoyarov:bucket4j-core:${bucket4jVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,28 +8,22 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-# For Nautilus 0-13-w11
-pravegaFlinkConnectorVersion=0.6.0
-pravegaCredentialsVersion=0.6.0
-pravegaVersion=0.6.0
-
-
 bucket4jVersion=4.4.1
 commonsCLIVersion=1.4
 flinkScalaVersion=2.12
-flinkVersion=1.7.2
 flinkShortVersion=1.7
+flinkVersion=1.7.2
 junitVersion=4.12
 logbackVersion=1.2.3
 logstashLogbackEncoderVersion=4.11
 nettyBoringSSLVersion=2.0.17.Final
 nettyVersion=4.1.30.Final
-# Below is for Nautilus 0.12.0
-# pravegaCredentialsVersion=0.6.0-2345.298015f-0.12.0-W5-001.4e5c9a1
-# See https://oss.jfrog.org/artifactory/jfrog-dependencies/io/pravega/pravega-connectors-flink_2.12/ for pre-release versions
-# pravegaFlinkConnectorVersion=0.6.0-158.9e3fa4d-SNAPSHOT
-# See https://oss.jfrog.org/artifactory/jfrog-dependencies/io/pravega/pravega-client/ for pre-release versions
-# pravegaVersion=0.6.0-2347.cd6bfe7-SNAPSHOT
+
+# For Nautilus 0-13-w11
+pravegaCredentialsVersion=0.6.0
+pravegaFlinkConnectorVersion=0.6.0
+pravegaVersion=0.6.0
+
 slf4jApiVersion=1.7.25
 
 # Set below to true when using Pravega in Nautilus.

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,21 +8,28 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
+# For Nautilus 0-13-w11
+pravegaFlinkConnectorVersion=0.6.0
+pravegaCredentialsVersion=0.6.0
+pravegaVersion=0.6.0
+
+
 bucket4jVersion=4.4.1
 commonsCLIVersion=1.4
 flinkScalaVersion=2.12
 flinkVersion=1.7.2
+flinkShortVersion=1.7
 junitVersion=4.12
 logbackVersion=1.2.3
 logstashLogbackEncoderVersion=4.11
 nettyBoringSSLVersion=2.0.17.Final
 nettyVersion=4.1.30.Final
 # Below is for Nautilus 0.12.0
-pravegaCredentialsVersion=0.6.0-2345.298015f-0.12.0-W5-001.4e5c9a1
+# pravegaCredentialsVersion=0.6.0-2345.298015f-0.12.0-W5-001.4e5c9a1
 # See https://oss.jfrog.org/artifactory/jfrog-dependencies/io/pravega/pravega-connectors-flink_2.12/ for pre-release versions
-pravegaFlinkConnectorVersion=0.6.0-158.9e3fa4d-SNAPSHOT
+# pravegaFlinkConnectorVersion=0.6.0-158.9e3fa4d-SNAPSHOT
 # See https://oss.jfrog.org/artifactory/jfrog-dependencies/io/pravega/pravega-client/ for pre-release versions
-pravegaVersion=0.6.0-2347.cd6bfe7-SNAPSHOT
+# pravegaVersion=0.6.0-2347.cd6bfe7-SNAPSHOT
 slf4jApiVersion=1.7.25
 
 # Set below to true when using Pravega in Nautilus.

--- a/video-player/build.gradle
+++ b/video-player/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile "org.bytedeco:javacv-platform:1.5.1"
     compile "io.pravega:pravega-client:${pravegaVersion}"
     if (includePravegaCredentials.toBoolean()) {
-        compile "io.pravega:pravega-keycloak-credentials:${pravegaCredentialsVersion}"
+        compile "io.pravega:pravega-keycloak-client:${pravegaCredentialsVersion}"
     }
     testCompile "junit:junit:${junitVersion}"
 }


### PR DESCRIPTION
this PR is for adding support with the new pravega version and tls://controller.fqdn:433
there is no need to download keycloak manually or build pravega and flink-connector

modified:   README.md
modified:   gradle.properties
modified:   camera-recorder/build.gradle
modified:   flinkprocessor/build.gradle
modified:   video-player/build.gradle
